### PR TITLE
Add a prettier config file to work with existing prettier eslint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,14 @@
 {
   "parser": "babel-eslint",
   "extends": [
-    "eslint:recommended",
     "plugin:react/recommended",
     "plugin:prettier/recommended"
   ],
   "plugins": [
-    "react",
-    "prettier"
+    "react"
   ],
   "rules": {
-    "no-undef": [ 1 ],
-    "prettier/prettier": ["error", { "singleQuote": true }]
+    "no-undef": [1]
   },
   "settings": {
     "react": {

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  semi: false,
+  singleQuote: true
+}

--- a/src/containers/BrowseEverything.js
+++ b/src/containers/BrowseEverything.js
@@ -9,14 +9,14 @@ const store = configureStore()
  * Example of handler for updating the DOM once an upload has completed
  */
 const handleUpload = function(event) {
-  console.log(event);
+  console.log(event)
 }
 
 export default class BrowseEverything extends Component {
   render() {
     return (
       <Provider store={store}>
-        <App onUpload={handleUpload}/>
+        <App onUpload={handleUpload} />
       </Provider>
     )
   }


### PR DESCRIPTION
Adds Prettier config in the `.prettierrc.js` file and gets IDEs to respect it.